### PR TITLE
Added websocket server

### DIFF
--- a/exampleCpp.hxml
+++ b/exampleCpp.hxml
@@ -1,0 +1,3 @@
+-cpp output/outCpp
+-cp src
+-main haxe.net.example.WebSocketExample

--- a/serverExample.hxml
+++ b/serverExample.hxml
@@ -1,0 +1,9 @@
+-neko output/serverExample.n
+-cp src
+-main haxe.net.example.WebSocketServerExample
+
+--next
+
+-cpp output/serverExampleCpp
+-cp src
+-main haxe.net.example.WebSocketServerExample

--- a/src/haxe/net/Socket2.hx
+++ b/src/haxe/net/Socket2.hx
@@ -39,7 +39,7 @@ class Socket2 {
         #if flash
         return new haxe.net.impl.SocketFlash(host, port, secure, debug);
         #elseif sys
-        return new haxe.net.impl.SocketSys(host, port, secure, debug);
+        return haxe.net.impl.SocketSys.create(host, port, secure, debug);
         #else
         #error "Unsupported platform"
         #end

--- a/src/haxe/net/Socket2.hx
+++ b/src/haxe/net/Socket2.hx
@@ -44,4 +44,10 @@ class Socket2 {
         #error "Unsupported platform"
         #end
     }
+	
+	#if sys
+	static public function createFromExistingSocket(socket:sys.net.Socket, debug:Bool = false) {
+		return haxe.net.impl.SocketSys.createFromExistingSocket(socket, debug);
+	}
+	#end
 }

--- a/src/haxe/net/WebSocket.hx
+++ b/src/haxe/net/WebSocket.hx
@@ -15,7 +15,7 @@ class WebSocket {
                     return new haxe.net.impl.WebSocketFlashExternalInterface(url, protocols);
                 }
             #end
-            return new haxe.net.impl.WebSocketGeneric(url, protocols, origin, "wskey", debug);
+            return haxe.net.impl.WebSocketGeneric.create(url, protocols, origin, "wskey", debug);
         #end
     }
 

--- a/src/haxe/net/WebSocket.hx
+++ b/src/haxe/net/WebSocket.hx
@@ -18,6 +18,19 @@ class WebSocket {
             return haxe.net.impl.WebSocketGeneric.create(url, protocols, origin, "wskey", debug);
         #end
     }
+	
+	#if sys
+	/**
+	 * create server websocket from socket returned by accept()
+	 * wait for onopen() to be called before using websocket
+	 * @param	socket - accepted socket 
+	 * @param	alredyRecieved - data already read from socket, it should be no more then full http header
+	 * @param	debug - debug messages?
+	 */
+	static public function createFromAcceptedSocket(socket:Socket2, alreadyRecieved:String = '', debug:Bool = false):WebSocket {
+		return haxe.net.impl.WebSocketGeneric.createFromAcceptedSocket(socket, alreadyRecieved, debug);
+	}
+	#end
 
     static dynamic public function defer(callback: Void -> Void) {
         #if (flash || js)

--- a/src/haxe/net/WebSocket.hx
+++ b/src/haxe/net/WebSocket.hx
@@ -38,6 +38,10 @@ class WebSocket {
 	
 	public function close() {
 	}
+	
+	public function isOpen():Bool {
+		return false;
+	}
 
     public dynamic function onopen():Void {
     }

--- a/src/haxe/net/WebSocketServer.hx
+++ b/src/haxe/net/WebSocketServer.hx
@@ -1,7 +1,4 @@
 package haxe.net;
-import haxe.crypto.Base64;
-import haxe.crypto.Sha1;
-import haxe.io.Bytes;
 import haxe.net.impl.SocketSys;
 import haxe.net.impl.WebSocketGeneric;
 import sys.net.Host;
@@ -28,66 +25,7 @@ class WebSocketServer {
 	public function accept() {
 		var socket = _listenSocket.accept();
 		
-		var requestLines:Array<String> = [];
-		
-		while(true) {
-			var line = socket.input.readLine();
-			if (line == '') break;
-			requestLines.push(line);
-		}
-		
-		if (_isDebug) trace('Recieved request: \n${requestLines.join("\n")}');
-		
-		{
-			var request = requestLines.shift();
-			var regexp = ~/^GET (.*) HTTP\/1.1$/;
-			if (!regexp.match(request)) throw 'bad request';
-			var url = regexp.matched(1);
-			//TODO check url
-		}
-		
-		var acceptKey:String = {
-			var key:String = null;
-			var version:String = null;
-			var upgrade:String = null;
-			var connection:String = null;
-			var regexp = ~/^(.*): (.*)$/;
-			for (header in requestLines) {
-				if (!regexp.match(header)) throw 'bad request';
-				var name = regexp.matched(1);
-				var value = regexp.matched(2);
-				switch(name) {
-					case 'Sec-WebSocket-Key': key = value;
-					case 'Sec-WebSocket-Version': version = value;
-					case 'Upgrade': upgrade = value;
-					case 'Connection': connection = value;
-				}
-			}
-			
-			if (
-				version != '13' 
-				|| upgrade != 'websocket' 
-				|| connection.indexOf('Upgrade') < 0
-				|| key == null
-			) {
-				throw 'bad request';
-			}
-			
-			Base64.encode(Sha1.make(Bytes.ofString(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')));
-		}
-		
-		var responce = [
-			'HTTP/1.1 101 Switching Protocols',
-			'Upgrade: websocket',
-			'Connection: Upgrade',
-			'Sec-WebSocket-Accept: $acceptKey',
-			'',	''
-		];
-		socket.output.writeString(responce.join('\r\n'));
-		
-		if (_isDebug) trace('Websocket succefully connected');
-		
-		return WebSocketGeneric.createFromExistingSocket(SocketSys.createFromExistingSocket(socket, _isDebug), _isDebug);
+		return WebSocketGeneric.createFromAcceptedSocket(SocketSys.createFromExistingSocket(socket, _isDebug), '', _isDebug);
 	}
 	
 }

--- a/src/haxe/net/WebSocketServer.hx
+++ b/src/haxe/net/WebSocketServer.hx
@@ -25,7 +25,7 @@ class WebSocketServer {
 	public function accept():WebSocket {
 		try {
 			var socket = _listenSocket.accept();
-			return WebSocketGeneric.createFromAcceptedSocket(Socket2.createFromExistingSocket(socket, _isDebug), '', _isDebug);
+			return WebSocket.createFromAcceptedSocket(Socket2.createFromExistingSocket(socket, _isDebug), '', _isDebug);
 		}
 		catch (e:Dynamic) {
 			if (e == 'Blocking' || e == Error.Blocked) {

--- a/src/haxe/net/WebSocketServer.hx
+++ b/src/haxe/net/WebSocketServer.hx
@@ -1,0 +1,93 @@
+package haxe.net;
+import haxe.crypto.Base64;
+import haxe.crypto.Sha1;
+import haxe.io.Bytes;
+import haxe.net.impl.SocketSys;
+import haxe.net.impl.WebSocketGeneric;
+import sys.net.Host;
+import sys.net.Socket;
+
+class WebSocketServer { 
+
+	var _isDebug:Bool;
+	var _listenSocket:Socket;
+	
+	function new(host:String, port:Int, maxConnections:Int, isDebug:Bool) {
+		_isDebug = isDebug;
+		_listenSocket = new Socket();
+		_listenSocket.bind(new Host(host), port);
+		_listenSocket.listen(maxConnections);
+	}
+	
+	public static function create(host:String, port:Int, maxConnections:Int, isDebug:Bool) {
+		return new WebSocketServer(host, port, maxConnections, isDebug);
+	}
+	
+	@:access(haxe.net.impl.WebSocketGeneric.createFromExistingSocket)
+	@:access(haxe.net.impl.SocketSys.createFromExistingSocket)
+	public function accept() {
+		var socket = _listenSocket.accept();
+		
+		var requestLines:Array<String> = [];
+		
+		while(true) {
+			var line = socket.input.readLine();
+			if (line == '') break;
+			requestLines.push(line);
+		}
+		
+		if (_isDebug) trace('Recieved request: \n${requestLines.join("\n")}');
+		
+		{
+			var request = requestLines.shift();
+			var regexp = ~/^GET (.*) HTTP\/1.1$/;
+			if (!regexp.match(request)) throw 'bad request';
+			var url = regexp.matched(1);
+			//TODO check url
+		}
+		
+		var acceptKey:String = {
+			var key:String = null;
+			var version:String = null;
+			var upgrade:String = null;
+			var connection:String = null;
+			var regexp = ~/^(.*): (.*)$/;
+			for (header in requestLines) {
+				if (!regexp.match(header)) throw 'bad request';
+				var name = regexp.matched(1);
+				var value = regexp.matched(2);
+				switch(name) {
+					case 'Sec-WebSocket-Key': key = value;
+					case 'Sec-WebSocket-Version': version = value;
+					case 'Upgrade': upgrade = value;
+					case 'Connection': connection = value;
+				}
+			}
+			
+			if (
+				version != '13' 
+				|| upgrade != 'websocket' 
+				|| connection.indexOf('Upgrade') < 0
+				|| key == null
+			) {
+				throw 'bad request';
+			}
+			
+			Base64.encode(Sha1.make(Bytes.ofString(key + '258EAFA5-E914-47DA-95CA-C5AB0DC85B11')));
+		}
+		
+		var responce = [
+			'HTTP/1.1 101 Switching Protocols',
+			'Upgrade: websocket',
+			'Connection: Upgrade',
+			'Sec-WebSocket-Accept: $acceptKey',
+			'',	''
+		];
+		socket.output.writeString(responce.join('\r\n'));
+		
+		if (_isDebug) trace('Websocket succefully connected');
+		
+		return WebSocketGeneric.createFromExistingSocket(SocketSys.createFromExistingSocket(socket, _isDebug), _isDebug);
+	}
+	
+}

--- a/src/haxe/net/example/WebSocketServerExample.hx
+++ b/src/haxe/net/example/WebSocketServerExample.hx
@@ -1,0 +1,49 @@
+package haxe.net.example;
+
+import haxe.CallStack;
+import haxe.Json;
+import haxe.io.Bytes;
+import haxe.net.WebSocketServer;
+
+class WebSocketServerExample {
+	
+	static function main() {
+		var port = 8000;
+		var server = WebSocketServer.create('0.0.0.0', port, 1, true);
+		while (true) {
+			try{
+				trace('listening on port $port');
+			
+				var websocket = server.accept();
+				
+				websocket.onmessageString = function(message:String) {
+					trace('Recieved message: $message');
+					websocket.sendString('Your message was: $message');
+				}
+				
+				websocket.onmessageBytes = function(message:Bytes) {
+					trace('Recieved bytes message: $message');
+					websocket.sendBytes(message);
+				}
+				
+				websocket.onclose = function() {
+					trace('websocket closed');
+					websocket = null;
+				}
+				
+				websocket.sendString('hello from server');
+				
+				var n = 0;
+				while (websocket != null) {
+					websocket.process();
+					Sys.sleep(0.5);
+				}
+			}
+			catch (e:Dynamic) {
+				trace('Error', e);
+				trace(CallStack.exceptionStack());
+			}
+		}
+	}
+	
+}

--- a/src/haxe/net/example/WebSocketServerExample.hx
+++ b/src/haxe/net/example/WebSocketServerExample.hx
@@ -14,7 +14,10 @@ class WebSocketServerExample {
 			try{
 				trace('listening on port $port');
 			
-				var websocket = server.accept();
+				var websocket = null;
+				while (websocket == null) {
+					websocket = server.accept();
+				}
 				
 				websocket.onmessageString = function(message:String) {
 					trace('Recieved message: $message');
@@ -31,10 +34,15 @@ class WebSocketServerExample {
 					websocket = null;
 				}
 				
-				websocket.sendString('hello from server');
+				var wasMessageSent:Bool = false;
 				
 				var n = 0;
 				while (websocket != null) {
+					if (websocket.isOpen() && !wasMessageSent) {
+						websocket.sendString('hello from server');						
+						wasMessageSent = true;
+					}
+					
 					websocket.process();
 					Sys.sleep(0.5);
 				}

--- a/src/haxe/net/impl/SocketSys.hx
+++ b/src/haxe/net/impl/SocketSys.hx
@@ -58,6 +58,7 @@ class SocketSys extends Socket2 {
     override public function close() {
 		this.impl.close();
 		if (!wasCloseSent) {
+			
 			wasCloseSent = true;
 			if (debug) trace('socket.onclose!');
 			onclose();
@@ -93,11 +94,13 @@ class SocketSys extends Socket2 {
 					}
 				} catch (e:Dynamic) {
 					needClose = !(Std.is(e, Error) && (e:Error).match(Error.Blocked));
+					if(needClose && debug) trace('closing socket because of $e');
 				}
 				ondata(out.readAllAvailableBytes());
 			}
 		}
 		catch (e:Dynamic) {
+			if(debug) trace('closing socket because of $e');
 			needClose = true;
 		}
 		

--- a/src/haxe/net/impl/SocketSys.hx
+++ b/src/haxe/net/impl/SocketSys.hx
@@ -47,7 +47,7 @@ class SocketSys extends Socket2 {
 		return new SocketSys(host, port, debug).initialize(secure);
 	}
 	
-	static function createFromExistingSocket(socket:sys.net.Socket, debug:Bool) {
+	static function createFromExistingSocket(socket:sys.net.Socket, debug:Bool = false) {
 		var socketSys = new SocketSys(socket.host().host.host, socket.host().port, debug);
 		socket.setBlocking(false);
 		socketSys.impl = socket;
@@ -93,7 +93,7 @@ class SocketSys extends Socket2 {
 						out.writeBytes(data.sub(0, readed));
 					}
 				} catch (e:Dynamic) {
-					needClose = !(Std.is(e, Error) && (e:Error).match(Error.Blocked));
+					needClose = !(e == 'Blocking' || (Std.is(e, Error) && (e:Error).match(Error.Blocked)));
 					if(needClose && debug) trace('closing socket because of $e');
 				}
 				ondata(out.readAllAvailableBytes());

--- a/src/haxe/net/impl/WebSocketGeneric.hx
+++ b/src/haxe/net/impl/WebSocketGeneric.hx
@@ -137,14 +137,14 @@ class WebSocketGeneric extends WebSocket {
 					try {
 						var handshake = prepareServerHandshake();
 						_debug('Sending responce: $handshake');
-						socket.send(Bytes.ofString(handshake));
+						writeBytes(Bytes.ofString(handshake));
 						
 						this.onopen();
 						
 						state = State.Head;
 					}
 					catch (e:String) {
-						socket.send(Bytes.ofString(prepareHttp400(e)));
+						writeBytes(Bytes.ofString(prepareHttp400(e)));
 						_debug('Error in http request: $e');
 						socket.close();
 						state = State.Closed;

--- a/src/haxe/net/impl/WebSocketGeneric.hx
+++ b/src/haxe/net/impl/WebSocketGeneric.hx
@@ -72,6 +72,7 @@ class WebSocketGeneric extends WebSocket {
 	
 	/**
 	 * create server websocket from socket returned by accept()
+	 * wait for onopen() to be called before using websocket
 	 * @param	socket - accepted socket 
 	 * @param	alredyRecieved - data already read from socket, it should be no more then full http header
 	 * @param	debug - debug messages?
@@ -339,12 +340,26 @@ class WebSocketGeneric extends WebSocket {
     private function sendFrame(data:Bytes, type:Opcode) {
         writeBytes(prepareFrame(data, type, true));
     }
+	
+	override public function isOpen():Bool {
+		return switch(state) {
+    		case Handshake: false;
+			case ServerHandshake: false;
+    		case Head: true;
+    		case HeadExtraLength: true;
+    		case HeadExtraMask: true;
+    		case Body: true;
+			case Closed: false;
+		}
+	}
 
     override public function sendString(message:String) {
+		if (!isOpen()) throw('websocket not open');
         sendFrame(Utf8Encoder.encode(message), Opcode.Text);
     }
 
     override public function sendBytes(message:Bytes) {
+		if (!isOpen()) throw('websocket not open');
         sendFrame(message, Opcode.Binary);
     }
 

--- a/src/haxe/net/impl/WebSocketGeneric.hx
+++ b/src/haxe/net/impl/WebSocketGeneric.hx
@@ -66,24 +66,17 @@ class WebSocketGeneric extends WebSocket {
         };
 	}
 	
-	public static function create(uri:String, protocols:Array<String> = null, origin:String = null, key:String = "wskey", debug:Bool = true) {
+	public static function create(uri:String, protocols:Array<String> = null, origin:String = null, key:String = "wskey", debug:Bool) {
 		return new WebSocketGeneric().initialize(uri, protocols, origin, key, debug);
 	}
 	
-	/**
-	 * create server websocket from socket returned by accept()
-	 * wait for onopen() to be called before using websocket
-	 * @param	socket - accepted socket 
-	 * @param	alredyRecieved - data already read from socket, it should be no more then full http header
-	 * @param	debug - debug messages?
-	 */
-	public static function createFromAcceptedSocket(socket:Socket2, alredyRecieved:String = '', debug:Bool = true) {
+	public static function createFromAcceptedSocket(socket:Socket2, alreadyRecieved:String = '', debug:Bool) {
 		var websocket = new WebSocketGeneric();
 		websocket.socket = socket;
 		websocket.debug = debug;
 		websocket.commonInitialize();
 		websocket.state = State.ServerHandshake;
-		websocket.httpHeader = alredyRecieved;
+		websocket.httpHeader = alreadyRecieved;
 		return websocket;
 	}
 

--- a/src/haxe/net/impl/WebSocketJs.hx
+++ b/src/haxe/net/impl/WebSocketJs.hx
@@ -57,4 +57,8 @@ class WebSocketJs extends WebSocket {
 	override public function close() {
 		this.impl.close();
 	}
+	
+	override public function isOpen():Bool {
+		return this.impl.readyState == js.html.WebSocket.OPEN;
+	}
 }


### PR DESCRIPTION
I needed a simple haxe websocket server and implementation for client and server only differs in handshake, so I decided to add this functionality to your library as the fastest and easiest way.

There is class WebSocketServer. But sometimes you want to serve normal HTTP requests and websocket on one port, in this case it is possible to use WebSocket.createFromAcceptedSocket(). 

I also added the example in WebSocketServerExample class.

For obvious reasons this is only for sys target. But I did not test on neko, because in latest haxe, select() is broken in neko.