### PR TITLE
Added new state: connecting to socket.

### DIFF
--- a/src/haxe/net/impl/WebSocketGeneric.hx
+++ b/src/haxe/net/impl/WebSocketGeneric.hx
@@ -15,7 +15,7 @@ class WebSocketGeneric extends WebSocket {
     public var path(default, null) = "/";
     private var secure = false;
     private var protocols = [];
-    private var state = State.Handshake;
+    private var state = State.Closed;
     public var debug:Bool = true;
     private var needHandleData:Bool = false;
 
@@ -41,8 +41,9 @@ class WebSocketGeneric extends WebSocket {
         //trace('$scheme, $host, $port, $path');
 
         socket = Socket2.create(host, port, secure, debug);
-        state = State.Handshake;
+        state = State.ConnectingToSocket;
         socket.onconnect = function() {
+            state = State.Handshake;
             _debug('socket connected');
             writeBytes(prepareClientHandshake(path, host, port, key, origin));
             //this.onopen();
@@ -330,11 +331,11 @@ class WebSocketGeneric extends WebSocket {
     }
 
     override public function close() {
-		if(state != State.Closed) {
-			sendFrame(Bytes.alloc(0), Opcode.Close);
-			socket.close();
-			setClosed();
-		}
+        if(state != State.Closed && state != State.ConnectingToSocket) {
+            sendFrame(Bytes.alloc(0), Opcode.Close);
+        }
+        socket.close();
+        setClosed();
     }
 
     private function sendFrame(data:Bytes, type:Opcode) {
@@ -343,6 +344,7 @@ class WebSocketGeneric extends WebSocket {
     
     override function get_readyState():ReadyState {
         return switch(state) {
+            case ConnectingToSocket: ReadyState.Connecting;
             case Handshake: ReadyState.Connecting;
             case ServerHandshake: ReadyState.Connecting;
             case Head: ReadyState.Open;
@@ -405,6 +407,7 @@ class WebSocketGeneric extends WebSocket {
 }
 
 enum State {
+    ConnectingToSocket;
     Handshake;
     ServerHandshake;
     Head;


### PR DESCRIPTION
So that close() will not try to send anything to socket if it is not open.
In my case it was leading to infinite recursion. In my `onerror()` handler I was calling `close()` which was calling `onerror()` because socket is not open.