### PR TITLE
Prevent calling impl.close() more than once

### DIFF
--- a/src/haxe/net/impl/SocketSys.hx
+++ b/src/haxe/net/impl/SocketSys.hx
@@ -57,6 +57,7 @@ class SocketSys extends Socket2 {
 
     override public function close() {
 		this.impl.close();
+        isClosed = true;
 		if (!wasCloseSent) {
 			
 			wasCloseSent = true;
@@ -110,7 +111,7 @@ class SocketSys extends Socket2 {
 			}
 		}
 		
-		if (needClose) {
+		if (needClose && !isClosed) {
 			    close();
 		}
     }


### PR DESCRIPTION
There was a possibility of getting succesive close() calls within process() from both ondata() https://github.com/soywiz/haxe-ws/blob/32b81123e4545742c0907473ad1690518cbf299d/src/haxe/net/impl/SocketSys.hx#L109 (via WebSocketGeneric's handleData()) and a direct call in https://github.com/soywiz/haxe-ws/blob/32b81123e4545742c0907473ad1690518cbf299d/src/haxe/net/impl/SocketSys.hx#L114. Which unsurprisingly led to Error,std@socket_close